### PR TITLE
[Bug修复](master): 修复定时任务管理存在SQL注入漏洞问题

### DIFF
--- a/eladmin-common/src/main/java/me/zhengjie/utils/SpringContextHolder.java
+++ b/eladmin-common/src/main/java/me/zhengjie/utils/SpringContextHolder.java
@@ -21,7 +21,9 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -141,5 +143,14 @@ public class SpringContextHolder implements ApplicationContextAware, DisposableB
             CALL_BACKS.clear();
         }
         SpringContextHolder.addCallback = false;
+    }
+
+    /**
+     * 获取 @Service 的所有 bean 名称
+     * @return /
+     */
+    public static List<String> getAllServiceBeanName() {
+        return new ArrayList<>(Arrays.asList(applicationContext
+                .getBeanNamesForAnnotation(Service.class)));
     }
 }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/quartz/rest/QuartzJobController.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/quartz/rest/QuartzJobController.java
@@ -24,6 +24,7 @@ import me.zhengjie.exception.BadRequestException;
 import me.zhengjie.modules.quartz.domain.QuartzJob;
 import me.zhengjie.modules.quartz.service.QuartzJobService;
 import me.zhengjie.modules.quartz.service.dto.JobQueryCriteria;
+import me.zhengjie.utils.SpringContextHolder;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -84,6 +85,8 @@ public class QuartzJobController {
         if (resources.getId() != null) {
             throw new BadRequestException("A new "+ ENTITY_NAME +" cannot already have an ID");
         }
+        // 验证Bean是不是合法的，合法的定时任务 Bean 需要用 @Service 定义
+        checkBean(resources.getBeanName());
         quartzJobService.create(resources);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
@@ -93,6 +96,8 @@ public class QuartzJobController {
     @PutMapping
     @PreAuthorize("@el.check('timing:edit')")
     public ResponseEntity<Object> updateQuartzJob(@Validated(QuartzJob.Update.class) @RequestBody QuartzJob resources){
+        // 验证Bean是不是合法的，合法的定时任务 Bean 需要用 @Service 定义
+        checkBean(resources.getBeanName());
         quartzJobService.update(resources);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
@@ -122,5 +127,13 @@ public class QuartzJobController {
     public ResponseEntity<Object> deleteQuartzJob(@RequestBody Set<Long> ids){
         quartzJobService.delete(ids);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    private void checkBean(String beanName){
+        // 避免调用攻击者可以从SpringContextHolder获得控制jdbcTemplate类
+        // 并使用getDeclaredMethod调用jdbcTemplate的queryForMap函数，执行任意sql命令。
+        if(!SpringContextHolder.getAllServiceBeanName().contains(beanName)){
+            throw new BadRequestException("非法的 Bean，请重新输入！");
+        }
     }
 }

--- a/eladmin-system/src/main/java/me/zhengjie/modules/quartz/task/TestTask.java
+++ b/eladmin-system/src/main/java/me/zhengjie/modules/quartz/task/TestTask.java
@@ -16,7 +16,7 @@
 package me.zhengjie.modules.quartz.task;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 /**
  * 测试用
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Component;
  * @date 2019-01-08
  */
 @Slf4j
-@Component
+@Service
 public class TestTask {
 
     public void run(){


### PR DESCRIPTION
由于定时任务未对Bean进行过滤，导致攻击者可以从SpringContextHolder获得控制jdbcTemplate类，并使用getDeclaredMethod调用jdbcTemplate的queryForMap函数，从而执行任意sql命令。

修复后定时任务的 Bean 需要使用 @Service 注解定义。